### PR TITLE
feat: Stripe Payment Elements on flight checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,7 @@ DUFFEL_BASE_URL=https://api.duffel.com
 DUFFEL_API_VERSION=v2
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Stripe — get your keys at https://dashboard.stripe.com/test/apikeys
+STRIPE_KEY=
+STRIPE_SECRET=

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -3,11 +3,15 @@
 namespace App\Http\Controllers;
 
 use App\Models\Booking;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
+use Stripe\Exception\ApiErrorException;
+use Stripe\PaymentIntent;
+use Stripe\Stripe;
 
 class CheckoutController extends Controller
 {
@@ -46,15 +50,15 @@ class CheckoutController extends Controller
     }
 
     // ──────────────────────────────────────────────────────────────
-    //  STEP 3 — Process booking (validate + save)
+    //  STEP 3 — Validate passengers, create Booking + PaymentIntent
     // ──────────────────────────────────────────────────────────────
 
-    public function storeFlight(Request $request): RedirectResponse
+    public function storeFlight(Request $request): JsonResponse
     {
         $offer = session('pending_flight_offer');
 
         if (empty($offer)) {
-            return redirect('/')->with('error', 'Session expired. Please search again.');
+            return response()->json(['error' => 'Session expired. Please search again.'], 422);
         }
 
         $validated = $request->validate([
@@ -73,19 +77,22 @@ class CheckoutController extends Controller
         ]);
 
         $reference = 'OB-' . strtoupper(Str::random(6));
+        $price     = (float) ($offer['price'] ?? 0);
+        $currency  = strtolower($offer['currency'] ?? 'usd');
 
+        // Create the booking (status: pending until payment confirmed)
         $booking = Booking::create([
-            'user_id'     => auth()->id(), // null for guests
-            'type'        => 'flight',
-            'reference'   => $reference,
-            'origin'      => $offer['origin']      ?? null,
-            'destination' => $offer['destination'] ?? null,
-            'depart_at'   => $offer['departs_at']  ?? null,
-            'passengers'  => count($validated['passengers']),
-            'cabin_class' => $offer['cabin_class'] ?? null,
-            'total_price' => $offer['price']       ?? 0,
-            'currency'    => $offer['currency']    ?? 'USD',
-            'status'      => 'pending',
+            'user_id'      => auth()->id(),
+            'type'         => 'flight',
+            'reference'    => $reference,
+            'origin'       => $offer['origin']      ?? null,
+            'destination'  => $offer['destination'] ?? null,
+            'depart_at'    => $offer['departs_at']  ?? null,
+            'passengers'   => count($validated['passengers']),
+            'cabin_class'  => $offer['cabin_class'] ?? null,
+            'total_price'  => $price,
+            'currency'     => strtoupper($currency),
+            'status'       => 'pending',
             'raw_response' => [
                 'offer'      => $offer,
                 'passengers' => $validated['passengers'],
@@ -96,14 +103,76 @@ class CheckoutController extends Controller
             ],
         ]);
 
-        // Clear session so they can't double-submit
+        // Create Stripe PaymentIntent
+        try {
+            Stripe::setApiKey(config('services.stripe.secret'));
+
+            $intent = PaymentIntent::create([
+                'amount'   => (int) round($price * 100), // Stripe uses cents
+                'currency' => $currency,
+                'metadata' => [
+                    'booking_reference' => $reference,
+                    'booking_id'        => $booking->id,
+                    'origin'            => $offer['origin']      ?? '',
+                    'destination'       => $offer['destination'] ?? '',
+                ],
+                'receipt_email'             => $validated['contact_email'],
+                'automatic_payment_methods' => ['enabled' => true],
+            ]);
+
+            return response()->json([
+                'client_secret' => $intent->client_secret,
+                'reference'     => $reference,
+            ]);
+        } catch (ApiErrorException $e) {
+            // Roll back the booking if Stripe fails
+            $booking->delete();
+
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    //  STEP 4 — Payment complete (Stripe redirects here)
+    //           Verify the PaymentIntent and confirm the booking
+    // ──────────────────────────────────────────────────────────────
+
+    public function completeFlight(Request $request): Response|RedirectResponse
+    {
+        $reference        = $request->query('reference');
+        $paymentIntentId  = $request->query('payment_intent');
+
+        $booking = Booking::where('reference', $reference)->first();
+
+        if (! $booking) {
+            return redirect('/')->with('error', 'Booking not found.');
+        }
+
+        // Verify payment with Stripe
+        if ($paymentIntentId && config('services.stripe.secret')) {
+            try {
+                Stripe::setApiKey(config('services.stripe.secret'));
+                $intent = PaymentIntent::retrieve($paymentIntentId);
+
+                if ($intent->status === 'succeeded') {
+                    $booking->update([
+                        'status'              => 'confirmed',
+                        'provider_booking_id' => $paymentIntentId,
+                    ]);
+                }
+            } catch (ApiErrorException $e) {
+                // Leave status as pending — booking still exists
+            }
+        }
+
+        // Clear session
         session()->forget('pending_flight_offer');
 
         return redirect()->route('booking.confirmation', ['reference' => $reference]);
     }
 
     // ──────────────────────────────────────────────────────────────
-    //  STEP 4 — Confirmation page
+    //  STEP 5 — Confirmation page
     // ──────────────────────────────────────────────────────────────
 
     public function confirmation(string $reference): Response|RedirectResponse
@@ -123,7 +192,7 @@ class CheckoutController extends Controller
                 'depart_at'   => $booking->depart_at,
                 'passengers'  => $booking->passengers,
                 'cabin_class' => $booking->cabin_class,
-                'total_price' => $booking->total_price,
+                'total_price' => (float) $booking->total_price,
                 'currency'    => $booking->currency,
                 'status'      => $booking->status,
                 'offer'       => $booking->raw_response['offer']      ?? [],

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,7 +37,8 @@ class HandleInertiaRequests extends Middleware
     {
         return [
             ...parent::share($request),
-            'name' => config('app.name'),
+            'name'       => config('app.name'),
+            'stripeKey'  => config('services.stripe.key'),
             'auth' => [
                 'user' => $request->user(),
             ],

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "laravel/fortify": "^1.34",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
-        "laravel/wayfinder": "^0.1.14"
+        "laravel/wayfinder": "^0.1.14",
+        "stripe/stripe-php": "^20.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da30706f0b4221e530835c43344df757",
+    "content-hash": "d9260724b9fc8aaf255ea43c8dcf0592",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3769,6 +3769,68 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v20.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/7338bd140e641b1f9c7cb602e2de971e14db6b3b",
+                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.94.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/version_check.php"
+                ],
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v20.0.0"
+            },
+            "time": "2026-03-26T01:57:48+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/services.php
+++ b/config/services.php
@@ -41,4 +41,9 @@ return [
         'api_version' => env('DUFFEL_API_VERSION', 'v2'),
     ],
 
+    'stripe' => [
+        'key'    => env('STRIPE_KEY'),
+        'secret' => env('STRIPE_SECRET'),
+    ],
+
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
             "dependencies": {
                 "@inertiajs/vite": "^3.0.0",
                 "@inertiajs/vue3": "^3.0.0",
+                "@stripe/stripe-js": "^9.1.0",
                 "@vueuse/core": "^12.8.2",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
@@ -978,6 +979,15 @@
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@stripe/stripe-js": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.1.0.tgz",
+            "integrity": "sha512-v51LoEfZNiNS/5DcarWPCYgn24w4dqwwALR4GTbMW/N0DDzzj4DgYNoixX6PYvpt6uIJMucGUabn/BHhylggIQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.16"
+            }
         },
         "node_modules/@stylistic/eslint-plugin": {
             "version": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
-        "@stylistic/eslint-plugin": "^5.10.0",
         "@laravel/vite-plugin-wayfinder": "^0.1.3",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^22.13.5",
         "@vitejs/plugin-vue": "^6.0.0",
@@ -36,6 +36,7 @@
     "dependencies": {
         "@inertiajs/vite": "^3.0.0",
         "@inertiajs/vue3": "^3.0.0",
+        "@stripe/stripe-js": "^9.1.0",
         "@vueuse/core": "^12.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/resources/js/pages/checkout/Flight.vue
+++ b/resources/js/pages/checkout/Flight.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { Head, useForm } from '@inertiajs/vue3';
-import { ref, computed } from 'vue';
-import { PlaneTakeoff, Clock, Users, ChevronDown, Lock, AlertCircle } from 'lucide-vue-next';
+import { Head, useForm, usePage } from '@inertiajs/vue3';
+import { ref, onMounted, computed } from 'vue';
+import { loadStripe, type Stripe, type StripeElements } from '@stripe/stripe-js';
+import { Lock, AlertCircle, PlaneTakeoff } from 'lucide-vue-next';
 import GuestLayout from '@/layouts/GuestLayout.vue';
 
 defineOptions({ layout: GuestLayout });
@@ -28,6 +29,9 @@ interface Offer {
 
 const props = defineProps<{ offer: Offer }>();
 
+const page       = usePage();
+const stripeKey  = computed(() => (page.props as any).stripeKey as string | null);
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 function formatTime(iso: string) {
     if (!iso) return '--:--';
@@ -41,16 +45,21 @@ function formatPrice(price: number, currency: string) {
     return new Intl.NumberFormat('en-US', { style: 'currency', currency, minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(price);
 }
 function parseDuration(iso: string) {
-    const m = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?/);
-    if (!m) return iso;
-    const h = m[1] ?? '0', min = m[2] ?? '0';
-    return `${h}h ${min}m`;
+    const m = iso?.match(/PT(?:(\d+)H)?(?:(\d+)M)?/);
+    if (!m) return iso ?? '';
+    return `${m[1] ?? 0}h ${m[2] ?? 0}m`;
 }
 function airlineLogoUrl(iata: string) {
     return `https://pics.avs.io/60/60/${iata}.png`;
 }
 
-// ── COUNTRIES (ISO 3166-1 alpha-2) ────────────────────────────────────────
+const cabinLabel: Record<string, string> = {
+    economy: 'Economy', premium_economy: 'Premium Economy',
+    business: 'Business', first: 'First Class',
+    ECONOMY: 'Economy', PREMIUM_ECONOMY: 'Premium Economy',
+    BUSINESS: 'Business', FIRST: 'First Class',
+};
+
 const COUNTRIES = [
     { code: 'GB', name: 'United Kingdom' }, { code: 'US', name: 'United States' },
     { code: 'NG', name: 'Nigeria' }, { code: 'GH', name: 'Ghana' },
@@ -61,26 +70,16 @@ const COUNTRIES = [
     { code: 'ES', name: 'Spain' }, { code: 'NL', name: 'Netherlands' },
     { code: 'AE', name: 'UAE' }, { code: 'QA', name: 'Qatar' },
     { code: 'SG', name: 'Singapore' }, { code: 'IN', name: 'India' },
-    { code: 'CN', name: 'China' }, { code: 'JP', name: 'Japan' },
     { code: 'AU', name: 'Australia' }, { code: 'CA', name: 'Canada' },
-    { code: 'BR', name: 'Brazil' }, { code: 'TR', name: 'Turkey' },
+    { code: 'TR', name: 'Turkey' }, { code: 'BR', name: 'Brazil' },
 ];
 
-// ── Passenger count derived from offer (1 adult default) ──────────────────
-// In a real implementation this would come from the original search params.
-// We store them in the offer's raw field or default to 1.
+// ── Passenger form ─────────────────────────────────────────────────────────
 const passengerCount = 1;
-
-// ── Form ───────────────────────────────────────────────────────────────────
 const passengerTemplate = () => ({
-    title: 'mr',
-    first_name: '',
-    last_name: '',
-    date_of_birth: '',
-    gender: 'm',
-    passport_number: '',
-    passport_expiry: '',
-    nationality: 'GB',
+    title: 'mr', first_name: '', last_name: '',
+    date_of_birth: '', gender: 'm',
+    passport_number: '', passport_expiry: '', nationality: 'GB',
 });
 
 const form = useForm({
@@ -89,165 +88,306 @@ const form = useForm({
     passengers: Array.from({ length: passengerCount }, passengerTemplate),
 });
 
-function submit() {
-    form.post('/checkout/flight');
+const todayStr = new Date().toISOString().split('T')[0];
+
+// ── Stripe state ───────────────────────────────────────────────────────────
+const stripe        = ref<Stripe | null>(null);
+const elements      = ref<StripeElements | null>(null);
+const paymentEl     = ref<HTMLElement | null>(null);
+const stripeReady   = ref(false);
+const stripeError   = ref('');
+const step          = ref<'details' | 'payment'>('details');
+const processing    = ref(false);
+const generalError  = ref('');
+
+// Step 1: validate passenger details, POST to backend → get client_secret
+async function proceedToPayment() {
+    generalError.value = '';
+
+    // Trigger Inertia form validation by submitting — but we need JSON back,
+    // so we do a manual fetch instead of form.post()
+    processing.value = true;
+
+    try {
+        const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+
+        const res = await fetch('/checkout/flight', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-CSRF-TOKEN': csrf,
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({
+                contact_email: form.contact_email,
+                contact_phone: form.contact_phone,
+                passengers:    form.passengers,
+            }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+            // Laravel validation errors come back as { errors: { field: ['msg'] } }
+            if (data.errors) {
+                Object.keys(data.errors).forEach(key => {
+                    (form.errors as any)[key] = data.errors[key][0];
+                });
+            }
+            generalError.value = data.message || 'Please fix the errors above.';
+            processing.value = false;
+            return;
+        }
+
+        // Mount Stripe Payment Element with the client_secret
+        await mountStripe(data.client_secret, data.reference);
+        step.value = 'payment';
+
+    } catch (e) {
+        generalError.value = 'Something went wrong. Please try again.';
+    } finally {
+        processing.value = false;
+    }
 }
 
-const todayStr = new Date().toISOString().split('T')[0];
-const cabinLabel: Record<string, string> = {
-    economy: 'Economy', premium_economy: 'Premium Economy',
-    business: 'Business', first: 'First Class',
-    ECONOMY: 'Economy', PREMIUM_ECONOMY: 'Premium Economy',
-    BUSINESS: 'Business', FIRST: 'First Class',
-};
+// Step 2: mount Stripe Elements after getting client_secret
+async function mountStripe(clientSecret: string, reference: string) {
+    if (!stripeKey.value) {
+        stripeError.value = 'Stripe is not configured.';
+        return;
+    }
+
+    stripe.value = await loadStripe(stripeKey.value);
+    if (!stripe.value) { stripeError.value = 'Failed to load Stripe.'; return; }
+
+    elements.value = stripe.value.elements({
+        clientSecret,
+        appearance: {
+            theme: 'stripe',
+            variables: {
+                colorPrimary: '#1c64f2',
+                fontFamily:   'Inter, ui-sans-serif, system-ui, sans-serif',
+                borderRadius: '8px',
+            },
+        },
+    });
+
+    const el = elements.value.create('payment', { layout: 'tabs' });
+
+    // Wait for DOM to update, then mount
+    await new Promise(r => setTimeout(r, 50));
+    if (paymentEl.value) el.mount(paymentEl.value);
+
+    stripeReady.value = true;
+
+    // Store reference so completeFlight route knows which booking to confirm
+    sessionStorage.setItem('pending_reference', reference);
+}
+
+// Step 3: confirm payment
+async function confirmPayment() {
+    if (!stripe.value || !elements.value) return;
+    processing.value = true;
+    stripeError.value = '';
+
+    const reference = sessionStorage.getItem('pending_reference') ?? '';
+    const returnUrl = `${window.location.origin}/checkout/flight/complete?reference=${reference}`;
+
+    const { error } = await stripe.value.confirmPayment({
+        elements: elements.value,
+        confirmParams: { return_url: returnUrl },
+    });
+
+    // If we get here, confirmPayment redirected or failed
+    if (error) {
+        stripeError.value = error.message ?? 'Payment failed. Please try again.';
+        processing.value = false;
+    }
+}
 </script>
 
 <template>
     <Head :title="`Checkout — ${offer.origin} → ${offer.destination} — Obiala`" />
 
     <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6">
-        <h1 class="mb-6 text-2xl font-bold text-gray-900" style="font-family:'Plus Jakarta Sans',sans-serif;">
+        <h1 class="mb-2 text-2xl font-bold text-gray-900" style="font-family:'Plus Jakarta Sans',sans-serif;">
             Complete your booking
         </h1>
 
+        <!-- Step indicator -->
+        <div class="mb-6 flex items-center gap-2 text-sm">
+            <span :class="['font-semibold', step === 'details' ? 'text-blue-600' : 'text-gray-400']">
+                1. Passenger details
+            </span>
+            <span class="text-gray-300">→</span>
+            <span :class="['font-semibold', step === 'payment' ? 'text-blue-600' : 'text-gray-400']">
+                2. Payment
+            </span>
+        </div>
+
         <div class="flex flex-col gap-6 lg:flex-row lg:items-start">
 
-            <!-- ── LEFT: Passenger form ──────────────────────────── -->
+            <!-- ── LEFT: Form ────────────────────────────────────── -->
             <div class="min-w-0 flex-1">
 
-                <!-- Global error -->
-                <div v-if="form.errors && Object.keys(form.errors).length"
-                     class="mb-5 flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
-                    <AlertCircle class="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" />
-                    <div>
-                        <p class="text-sm font-semibold text-red-700">Please fix the errors below before continuing.</p>
-                    </div>
-                </div>
+                <!-- ── STEP 1: Passenger details ─────────────────── -->
+                <template v-if="step === 'details'">
 
-                <!-- Contact info -->
-                <section class="mb-5 rounded-xl border border-gray-200 bg-white p-5">
-                    <h2 class="mb-4 font-semibold text-gray-900">Contact details</h2>
-                    <div class="grid gap-4 sm:grid-cols-2">
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Email address *</label>
-                            <input v-model="form.contact_email" type="email" placeholder="you@email.com"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors.contact_email ? 'border-red-400 bg-red-50' : 'border-gray-200']" />
-                            <p v-if="form.errors.contact_email" class="mt-1 text-xs text-red-600">{{ form.errors.contact_email }}</p>
-                        </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Phone number *</label>
-                            <input v-model="form.contact_phone" type="tel" placeholder="+44 7700 900000"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors.contact_phone ? 'border-red-400 bg-red-50' : 'border-gray-200']" />
-                            <p v-if="form.errors.contact_phone" class="mt-1 text-xs text-red-600">{{ form.errors.contact_phone }}</p>
-                        </div>
-                    </div>
-                    <p class="mt-2 text-xs text-gray-400">Your booking confirmation and e-ticket will be sent to this email.</p>
-                </section>
-
-                <!-- Passenger forms -->
-                <section v-for="(pax, idx) in form.passengers" :key="idx"
-                         class="mb-5 rounded-xl border border-gray-200 bg-white p-5">
-                    <h2 class="mb-4 font-semibold text-gray-900">
-                        Passenger {{ idx + 1 }}
-                        <span class="ml-2 text-xs font-normal text-gray-400">Adult</span>
-                    </h2>
-
-                    <!-- Row 1: Title / First / Last -->
-                    <div class="mb-4 grid gap-3 sm:grid-cols-[100px_1fr_1fr]">
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Title *</label>
-                            <select v-model="pax.title"
-                                    class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-blue-500">
-                                <option value="mr">Mr</option>
-                                <option value="mrs">Mrs</option>
-                                <option value="ms">Ms</option>
-                                <option value="dr">Dr</option>
-                            </select>
-                        </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">First name *</label>
-                            <input v-model="pax.first_name" type="text" placeholder="As on passport"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors[`passengers.${idx}.first_name`] ? 'border-red-400' : 'border-gray-200']" />
-                            <p v-if="form.errors[`passengers.${idx}.first_name`]" class="mt-1 text-xs text-red-600">
-                                {{ form.errors[`passengers.${idx}.first_name`] }}
-                            </p>
-                        </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Last name *</label>
-                            <input v-model="pax.last_name" type="text" placeholder="As on passport"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors[`passengers.${idx}.last_name`] ? 'border-red-400' : 'border-gray-200']" />
-                            <p v-if="form.errors[`passengers.${idx}.last_name`]" class="mt-1 text-xs text-red-600">
-                                {{ form.errors[`passengers.${idx}.last_name`] }}
-                            </p>
-                        </div>
+                    <!-- Global error -->
+                    <div v-if="generalError"
+                         class="mb-5 flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
+                        <AlertCircle class="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" />
+                        <p class="text-sm font-medium text-red-700">{{ generalError }}</p>
                     </div>
 
-                    <!-- Row 2: DOB / Gender / Nationality -->
-                    <div class="mb-4 grid gap-3 sm:grid-cols-3">
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Date of birth *</label>
-                            <input v-model="pax.date_of_birth" type="date" :max="todayStr"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors[`passengers.${idx}.date_of_birth`] ? 'border-red-400' : 'border-gray-200']" />
-                            <p v-if="form.errors[`passengers.${idx}.date_of_birth`]" class="mt-1 text-xs text-red-600">
-                                {{ form.errors[`passengers.${idx}.date_of_birth`] }}
-                            </p>
+                    <!-- Contact info -->
+                    <section class="mb-5 rounded-xl border border-gray-200 bg-white p-5">
+                        <h2 class="mb-4 font-semibold text-gray-900">Contact details</h2>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Email address *</label>
+                                <input v-model="form.contact_email" type="email" placeholder="you@email.com"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors.contact_email ? 'border-red-400 bg-red-50' : 'border-gray-200']" />
+                                <p v-if="form.errors.contact_email" class="mt-1 text-xs text-red-600">{{ form.errors.contact_email }}</p>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Phone number *</label>
+                                <input v-model="form.contact_phone" type="tel" placeholder="+44 7700 900000"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors.contact_phone ? 'border-red-400 bg-red-50' : 'border-gray-200']" />
+                                <p v-if="form.errors.contact_phone" class="mt-1 text-xs text-red-600">{{ form.errors.contact_phone }}</p>
+                            </div>
                         </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Gender *</label>
-                            <select v-model="pax.gender"
-                                    class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-blue-500">
-                                <option value="m">Male</option>
-                                <option value="f">Female</option>
-                            </select>
-                        </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Nationality *</label>
-                            <select v-model="pax.nationality"
-                                    :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500',
-                                             form.errors[`passengers.${idx}.nationality`] ? 'border-red-400' : 'border-gray-200']">
-                                <option v-for="c in COUNTRIES" :key="c.code" :value="c.code">{{ c.name }}</option>
-                            </select>
-                        </div>
-                    </div>
+                        <p class="mt-2 text-xs text-gray-400">Booking confirmation and e-ticket will be sent here.</p>
+                    </section>
 
-                    <!-- Row 3: Passport number / Expiry -->
-                    <div class="grid gap-3 sm:grid-cols-2">
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Passport / ID number *</label>
-                            <input v-model="pax.passport_number" type="text" placeholder="e.g. 123456789"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors[`passengers.${idx}.passport_number`] ? 'border-red-400' : 'border-gray-200']" />
-                            <p v-if="form.errors[`passengers.${idx}.passport_number`]" class="mt-1 text-xs text-red-600">
-                                {{ form.errors[`passengers.${idx}.passport_number`] }}
-                            </p>
-                        </div>
-                        <div>
-                            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Passport expiry *</label>
-                            <input v-model="pax.passport_expiry" type="date" :min="todayStr"
-                                   :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
-                                            form.errors[`passengers.${idx}.passport_expiry`] ? 'border-red-400' : 'border-gray-200']" />
-                            <p v-if="form.errors[`passengers.${idx}.passport_expiry`]" class="mt-1 text-xs text-red-600">
-                                {{ form.errors[`passengers.${idx}.passport_expiry`] }}
-                            </p>
-                        </div>
-                    </div>
-                </section>
+                    <!-- Passenger forms -->
+                    <section v-for="(pax, idx) in form.passengers" :key="idx"
+                             class="mb-5 rounded-xl border border-gray-200 bg-white p-5">
+                        <h2 class="mb-4 font-semibold text-gray-900">
+                            Passenger {{ idx + 1 }}
+                            <span class="ml-2 text-xs font-normal text-gray-400">Adult</span>
+                        </h2>
 
-                <!-- Submit -->
-                <button @click="submit" :disabled="form.processing"
-                        class="flex w-full items-center justify-center gap-2 rounded-xl py-3.5 text-base font-bold text-white shadow-md transition hover:opacity-90 disabled:opacity-60"
-                        style="background:linear-gradient(135deg,#1c64f2,#0ea5e9)">
-                    <Lock class="h-4 w-4" />
-                    {{ form.processing ? 'Processing...' : 'Confirm booking' }}
-                </button>
-                <p class="mt-2 text-center text-xs text-gray-400">
-                    🔒 Your data is encrypted and never shared with third parties.
-                </p>
+                        <!-- Title / First / Last -->
+                        <div class="mb-4 grid gap-3 sm:grid-cols-[100px_1fr_1fr]">
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Title *</label>
+                                <select v-model="pax.title" class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-blue-500">
+                                    <option value="mr">Mr</option>
+                                    <option value="mrs">Mrs</option>
+                                    <option value="ms">Ms</option>
+                                    <option value="dr">Dr</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">First name *</label>
+                                <input v-model="pax.first_name" type="text" placeholder="As on passport"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors[`passengers.${idx}.first_name`] ? 'border-red-400' : 'border-gray-200']" />
+                                <p v-if="form.errors[`passengers.${idx}.first_name`]" class="mt-1 text-xs text-red-600">{{ form.errors[`passengers.${idx}.first_name`] }}</p>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Last name *</label>
+                                <input v-model="pax.last_name" type="text" placeholder="As on passport"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors[`passengers.${idx}.last_name`] ? 'border-red-400' : 'border-gray-200']" />
+                                <p v-if="form.errors[`passengers.${idx}.last_name`]" class="mt-1 text-xs text-red-600">{{ form.errors[`passengers.${idx}.last_name`] }}</p>
+                            </div>
+                        </div>
+
+                        <!-- DOB / Gender / Nationality -->
+                        <div class="mb-4 grid gap-3 sm:grid-cols-3">
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Date of birth *</label>
+                                <input v-model="pax.date_of_birth" type="date" :max="todayStr"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors[`passengers.${idx}.date_of_birth`] ? 'border-red-400' : 'border-gray-200']" />
+                                <p v-if="form.errors[`passengers.${idx}.date_of_birth`]" class="mt-1 text-xs text-red-600">{{ form.errors[`passengers.${idx}.date_of_birth`] }}</p>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Gender *</label>
+                                <select v-model="pax.gender" class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-blue-500">
+                                    <option value="m">Male</option>
+                                    <option value="f">Female</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Nationality *</label>
+                                <select v-model="pax.nationality"
+                                        :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500',
+                                                 form.errors[`passengers.${idx}.nationality`] ? 'border-red-400' : 'border-gray-200']">
+                                    <option v-for="c in COUNTRIES" :key="c.code" :value="c.code">{{ c.name }}</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <!-- Passport number / Expiry -->
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Passport / ID number *</label>
+                                <input v-model="pax.passport_number" type="text" placeholder="e.g. 123456789"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors[`passengers.${idx}.passport_number`] ? 'border-red-400' : 'border-gray-200']" />
+                                <p v-if="form.errors[`passengers.${idx}.passport_number`]" class="mt-1 text-xs text-red-600">{{ form.errors[`passengers.${idx}.passport_number`] }}</p>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">Passport expiry *</label>
+                                <input v-model="pax.passport_expiry" type="date" :min="todayStr"
+                                       :class="['w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100',
+                                                form.errors[`passengers.${idx}.passport_expiry`] ? 'border-red-400' : 'border-gray-200']" />
+                                <p v-if="form.errors[`passengers.${idx}.passport_expiry`]" class="mt-1 text-xs text-red-600">{{ form.errors[`passengers.${idx}.passport_expiry`] }}</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Continue button -->
+                    <button @click="proceedToPayment" :disabled="processing"
+                            class="flex w-full items-center justify-center gap-2 rounded-xl py-3.5 text-base font-bold text-white shadow-md transition hover:opacity-90 disabled:opacity-60"
+                            style="background:linear-gradient(135deg,#1c64f2,#0ea5e9)">
+                        {{ processing ? 'Saving details...' : `Continue to payment — ${formatPrice(offer.price, offer.currency)}` }}
+                    </button>
+                    <p class="mt-2 text-center text-xs text-gray-400">🔒 Encrypted and secure. You won't be charged yet.</p>
+                </template>
+
+                <!-- ── STEP 2: Stripe Payment Element ─────────────── -->
+                <template v-if="step === 'payment'">
+                    <section class="mb-5 rounded-xl border border-gray-200 bg-white p-5">
+                        <h2 class="mb-4 font-semibold text-gray-900">Payment details</h2>
+
+                        <!-- Stripe Payment Element mounts here -->
+                        <div ref="paymentEl" class="min-h-[120px]">
+                            <div v-if="!stripeReady" class="flex items-center gap-2 text-sm text-gray-400">
+                                <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+                                </svg>
+                                Loading payment form...
+                            </div>
+                        </div>
+
+                        <p v-if="stripeError" class="mt-3 text-sm font-medium text-red-600">⚠ {{ stripeError }}</p>
+                    </section>
+
+                    <!-- Pay button -->
+                    <button @click="confirmPayment" :disabled="processing || !stripeReady"
+                            class="flex w-full items-center justify-center gap-2 rounded-xl py-3.5 text-base font-bold text-white shadow-md transition hover:opacity-90 disabled:opacity-60"
+                            style="background:linear-gradient(135deg,#1c64f2,#0ea5e9)">
+                        <Lock class="h-4 w-4" />
+                        {{ processing ? 'Processing payment...' : `Pay ${formatPrice(offer.price, offer.currency)}` }}
+                    </button>
+
+                    <p class="mt-2 text-center text-xs text-gray-400">
+                        🔒 Payments processed securely by Stripe. We never store your card details.
+                    </p>
+
+                    <button @click="step = 'details'"
+                            class="mt-3 w-full text-center text-sm text-gray-400 underline hover:text-gray-600">
+                        ← Back to passenger details
+                    </button>
+                </template>
             </div>
 
             <!-- ── RIGHT: Order summary ───────────────────────────── -->
@@ -288,7 +428,7 @@ const cabinLabel: Record<string, string> = {
                         <p class="mt-2 text-center text-[11px] text-gray-400">{{ formatDate(offer.departs_at) }}</p>
                     </div>
 
-                    <!-- Details list -->
+                    <!-- Details -->
                     <div class="mb-4 flex flex-col gap-2 text-sm">
                         <div class="flex justify-between text-gray-600">
                             <span>Cabin</span>
@@ -300,22 +440,20 @@ const cabinLabel: Record<string, string> = {
                         </div>
                         <div class="flex justify-between text-gray-600">
                             <span>Carry-on</span>
-                            <span :class="offer.baggages.carry_on ? 'text-emerald-600 font-medium' : 'text-gray-400'">
+                            <span :class="offer.baggages.carry_on ? 'font-medium text-emerald-600' : 'text-gray-400'">
                                 {{ offer.baggages.carry_on ? '✓ Included' : 'Not included' }}
                             </span>
                         </div>
                         <div class="flex justify-between text-gray-600">
                             <span>Checked bag</span>
-                            <span :class="offer.baggages.checked ? 'text-emerald-600 font-medium' : 'text-gray-400'">
+                            <span :class="offer.baggages.checked ? 'font-medium text-emerald-600' : 'text-gray-400'">
                                 {{ offer.baggages.checked ? '✓ Included' : 'Not included' }}
                             </span>
                         </div>
                     </div>
 
-                    <!-- Divider -->
                     <div class="my-3 border-t border-gray-100"></div>
 
-                    <!-- Total -->
                     <div class="flex items-baseline justify-between">
                         <span class="text-sm font-semibold text-gray-700">Total</span>
                         <span class="text-2xl font-extrabold text-gray-900" style="font-family:'Plus Jakarta Sans',sans-serif;">
@@ -324,7 +462,6 @@ const cabinLabel: Record<string, string> = {
                     </div>
                     <p class="mt-1 text-right text-xs text-gray-400">All taxes and fees included</p>
 
-                    <!-- Trust badges -->
                     <div class="mt-4 flex flex-col gap-1.5 text-xs text-gray-400">
                         <span>🔒 Secure 256-bit SSL encryption</span>
                         <span>✈️ Instant booking confirmation</span>
@@ -332,7 +469,6 @@ const cabinLabel: Record<string, string> = {
                     </div>
                 </div>
             </div>
-
         </div>
     </div>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::get('/hotels/search', [HotelController::class, 'search'])->name('hotels.s
 Route::post('/checkout/flight/select', [CheckoutController::class, 'selectFlight'])->name('checkout.flight.select');
 Route::get('/checkout/flight', [CheckoutController::class, 'showFlight'])->name('checkout.flight');
 Route::post('/checkout/flight', [CheckoutController::class, 'storeFlight'])->name('checkout.flight.store');
+Route::get('/checkout/flight/complete', [CheckoutController::class, 'completeFlight'])->name('checkout.flight.complete');
 Route::get('/booking/{reference}', [CheckoutController::class, 'confirmation'])->name('booking.confirmation');
 
 // Authenticated routes


### PR DESCRIPTION
## Summary
- Installs `stripe/stripe-php` + `@stripe/stripe-js`
- Flight checkout now has a two-step flow: passenger details → Stripe payment
- Backend creates a `PaymentIntent` and returns a `client_secret` as JSON
- Frontend mounts Stripe Payment Element (supports card, Apple Pay, Google Pay)
- After payment, Stripe redirects to `/checkout/flight/complete` which verifies the `PaymentIntent` and marks the booking as `confirmed`
- `STRIPE_KEY` shared to all Inertia pages via `HandleInertiaRequests`

## Test plan
- [ ] Search a flight → Select → fill passenger form → Continue to payment
- [ ] Stripe Payment Element appears with card input
- [ ] Pay using test card `4242 4242 4242 4242`, any future expiry, any CVC
- [ ] Redirected to confirmation page with status `confirmed`
- [ ] Check `/bookings` — booking shows as confirmed
- [ ] Test declined card `4000 0000 0000 0002` — error message shown inline